### PR TITLE
returns packed fmt. Added flags feature

### DIFF
--- a/soft_webauthn.py
+++ b/soft_webauthn.py
@@ -95,8 +95,6 @@ class SoftWebauthnDevice():
             'attStmt': stmt
         }
 
-        print(attestation_object)
-
         return {
             'id': urlsafe_b64encode(self.credential_id),
             'rawId': self.credential_id,


### PR DESCRIPTION
- Authenticator will now return a `packed` (self-packed) formatted attestation response for `.create`. Previously, it was set to `none`. When 3DS is enabled on FIDO2-service, attestation objects set to `none` will fail the check. This will be accepted by the service because it is a valid statement.
- Flags feature to control what flags to be used.